### PR TITLE
@alloy - Avoid setting invalid status code

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,7 +8,8 @@ app.get('/', function(request, response) {
   response.sendFile(filename, options, function(error) {
     if (error) {
       console.log(error);
-      response.status(error.status).end();
+      code = error.status >= 100 && error.status < 600 ? error.status : 500
+      response.status(code).end();
     }
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-eigen-web-association",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A tiny app that serves the apple-app-site-association required for iOS Handoff related features.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Just got a range error here that made force restart!

`Uncaught Exception RangeError: Invalid status code: 0`
