### PR TITLE
@alloy => Version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-eigen-web-association",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A tiny app that serves the apple-app-site-association required for iOS Handoff related features.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
Not sure if this matters for places like force where we `yarn add` via the github url since it stores the commit sha in the yarn.lock file, but it doesn't hurt and we should bump anyway!