### PR TITLE
Exclude *all* Venice editorial links.

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -17,7 +17,7 @@
         "paths": [
           "NOT /article/*",
           "NOT /2016-year-in-art",
-          "NOT /venice-biennale",
+          "NOT /venice-biennale*",
           "NOT *L2FydGljbGUv*",
           "NOT *LzIwMTYteWVhci1pbi1hcnQ=*",
           "NOT *L3ZlbmljZS1iaWVubmFsZQ==*",


### PR DESCRIPTION
This should now also exclude e.g. https://www.artsy.net/venice-biennale/studio-venezia