### PR TITLE
Remove base64 padding

### DIFF
--- a/add-sailthru-paths.js
+++ b/add-sailthru-paths.js
@@ -6,7 +6,7 @@
  * (This specific link redirects to https://www.artsy.net/article/artsy-editorial-mets-roof-hosts-dinner-party-5-000-years-art-invited?utm_source=sailthru&utm_medium=email&utm_campaign=9466122-Editorial-04-25-17&utm_term=ArtsyTopStoriesWeekly)
  *
  * The problem with that is that iOS won’t be able to exclude paths in the normal way. However, it turns out that the
- * encoded URL contains a base64 version of the actual Artsy URL, so we can exlcude based on that. This script takes the
+ * encoded URL contains a base64 version of the actual Artsy URL, so we can exclude based on that. This script takes the
  * patterns specified in the apple-app-site-association.json file and generates the encoded versions of them. Or, if a
  * pattern was removed, it removes the corresponding encoded pattern.
  */
@@ -33,9 +33,16 @@ function encodePath(path) {
     .join("*")
 }
 
+/**
+ * Only encode upto the largest multiple of 3 so that no padding is required to encode to base64.
+ *
+ * Match everything before, which is going to be the domain (`https://www.artsy.net`) base64 encoded, and after because
+ * Sailthru adds another path component that we don’t care about.
+ */
 function encodePattern(pattern) {
   const path = pattern.match(/^NOT (.+)$/)[1]
-  return `NOT *${encodePath(path)}*`
+  const encoded = encodePath(path.slice(0, -(path.length % 3)))
+  return `NOT *${encoded}*`
 }
 
 updateFile(json => {

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -19,8 +19,8 @@
           "NOT /2016-year-in-art",
           "NOT /venice-biennale*",
           "NOT *L2FydGljbGUv*",
-          "NOT *LzIwMTYteWVhci1pbi1hcnQ=*",
-          "NOT *L3ZlbmljZS1iaWVubmFsZQ==*",
+          "NOT *LzIwMTYteWVhci1pbi1h*",
+          "NOT *L3ZlbmljZS1iaWVubmFs*",
           "*"
         ]
       }


### PR DESCRIPTION
Consider the following example:

```
$ curl -Is http://link.artsy.net/click/9692723.214027/aHR0cHM6Ly93d3cuYXJ0c3kubmV0L3ZlbmljZS1iaWVubmFsZS9zdHVkaW8tdmVuZXppYT91dG1fc291cmNlPXNhaWx0aHJ1JnV0bV9tZWRpdW09ZW1haWwmdXRtX2NhbXBhaWduPTk2OTI3MjMtMDUtMjUtMTctRWRpdG9yaWFsJnV0bV90ZXJtPUFydHN5RmVhdHVyZWRTdG9yaWVz/56d8ca89e9a8a2c4168b4f56Cfbb99b59 | grep Location

Location: https://www.artsy.net/venice-biennale/studio-venezia?utm_source=sailthru&utm_medium=email&utm_campaign=9692723-05-25-17-Editorial&utm_term=ArtsyFeaturedStories
```

The encoded pattern we have for this is `L3ZlbmljZS1iaWVubmFsZQ==`, which is not present in the encoded URL. That’s because Base64 encodes in chunks of 3 input bytes and pads the remainder, which means that if the unencoded pattern isn’t exactly a multiple of 3 characters long:

* the trailing `=` signs will be included, which will not be present in the encoded URL
* the last characters get encoded with the characters following

So instead of encoding `/venice-biennale` as `L3ZlbmljZS1iaWVubmFsZQ==`, or even `L3ZlbmljZS1iaWVubmFsZQ`, we only encode `/venice-biennale` to `L3ZlbmljZS1iaWVubmFs` which is present in the encoded URL.