### PR TITLE
@alloy => Add cache section to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ ones.
 
 ## Caching
 
-Apple caches the apple-app-site-association file on app install. This means any updates to the `apple-app-site-association` file will only affect users who have recently installed the app, updated the app, or turned Universal Linking [off (and on again)](https://stackoverflow.com/questions/32729489/how-can-i-reset-ios-9-universal-linking-settings). More details about how Apple caches this file can be found on this [Stack Overflow answer](https://stackoverflow.com/a/41305871).
+Apple caches the apple-app-site-association file on app install. If you're having trouble clearing the apple-app-site-association file cache on your device, try updating the app or turn Universal Linking [off (and on again)](https://stackoverflow.com/questions/32729489/how-can-i-reset-ios-9-universal-linking-settings). While it's not known how often the cache is updated, it does appear to periodically between installs and updates. More details about how Apple caches this file can be found on this [Stack Overflow answer](https://stackoverflow.com/a/41305871).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ For more information see:
 * [Handoff programming guide](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/AdoptingHandoff/AdoptingHandoff.html#//apple_ref/doc/uid/TP40014338-CH2-SW10)
 * [Universal Links programming guide](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
 * [Shared Web Credentials programming guide](https://developer.apple.com/library/ios/documentation/Security/Reference/SharedWebCredentialsRef/)
+* [Sailthru Universal Links Documentation](https://getstarted.sailthru.com/mobile/apple-ios-app-universal-links/)
+* [Sailthru UL FAQ](https://sailthru.zendesk.com/hc/en-us/articles/217102466-Universal-Links-Troubleshooting-and-FAQ)
 
 ## Serving config file
 
@@ -26,3 +28,7 @@ page](https://my.sailthru.com/settings/universal_links).
 When making changes, you should do so in the `apple-app-site-association.json`
 file and then run `yarn build` to encode new paths for Sailthru or remove old
 ones.
+
+## Caching
+
+Apple caches the apple-site-association file on app install. This means any updates to the `apple-site-association` file will only affect users who have recently installed the app, updated the app, or turned Universal Linking [off (and on again)](https://stackoverflow.com/questions/32729489/how-can-i-reset-ios-9-universal-linking-settings). More details about how Apple caches this file can be found on this [Stack Overflow answer](https://stackoverflow.com/a/41305871).

--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ ones.
 
 ## Caching
 
-Apple caches the apple-site-association file on app install. This means any updates to the `apple-site-association` file will only affect users who have recently installed the app, updated the app, or turned Universal Linking [off (and on again)](https://stackoverflow.com/questions/32729489/how-can-i-reset-ios-9-universal-linking-settings). More details about how Apple caches this file can be found on this [Stack Overflow answer](https://stackoverflow.com/a/41305871).
+Apple caches the apple-app-site-association file on app install. This means any updates to the `apple-app-site-association` file will only affect users who have recently installed the app, updated the app, or turned Universal Linking [off (and on again)](https://stackoverflow.com/questions/32729489/how-can-i-reset-ios-9-universal-linking-settings). More details about how Apple caches this file can be found on this [Stack Overflow answer](https://stackoverflow.com/a/41305871).


### PR DESCRIPTION
We found that the handoff still happened for _some_ people, even after `apple-site-association.json` was uploaded to Sailthru. The problem turned out to be that this file gets cached when a user first installs the app. So, to invalidate the cache and update to the latest `apple-site-association.json`, you have to reinstall the app, update the app if there is an update, or turn off UL once and turn it on again. This isn't ideal for updates to routes like /venice-biennale where we would need to make constant updates.

Pushing Sailthru to support multiple link domains per email won't solve the entire problem since people with old caches will still get redirected via other iOS apps. Unless we can find a way to bust that cache for all users magically, I think getting these features into a nested route might be a good solution. What do you think?
