### PR TITLE
Exclude sailthru links to podcast on iTunes.

### DIFF
--- a/add-sailthru-paths.js
+++ b/add-sailthru-paths.js
@@ -33,6 +33,10 @@ function encodePath(path) {
     .join("*")
 }
 
+function isNotSailthruPattern(pattern) {
+  return !/^NOT \/click\/\*/.test(pattern)
+}
+
 /**
  * Only encode upto the largest multiple of 3 so that no padding is required to encode to base64.
  *
@@ -48,5 +52,5 @@ function encodePattern(pattern) {
 updateFile(json => {
   const app = json.applinks.details[0]
   const patterns = unencodedPatterns(app.paths)
-  app.paths = [...patterns.concat(patterns.map(encodePattern)), "*"]
+  app.paths = [...patterns.concat(patterns.filter(isNotSailthruPattern).map(encodePattern)), "*"]
 })

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -18,6 +18,7 @@
           "NOT /article/*",
           "NOT /2016-year-in-art",
           "NOT /venice-biennale*",
+          "NOT /click/*/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kv*",
           "NOT *L2FydGljbGUv*",
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",


### PR DESCRIPTION
This makes sure URLs like the following are excluded:

```
$ curl -sI http://link.artsy.net/click/9878256.349300/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kvaWQxMDk2MTk0NTE2P210PTImdXRtX3NvdXJjZT1zYWlsdGhydSZ1dG1fbWVkaXVtPWVtYWlsJnV0bV9jYW1wYWlnbj05ODc4MjU2LTA2LTE5LTE3LUVkaXRvcmlhbCZ1dG1fY29udGVudD1iYW5uZXI/56969dcb487ccd431a8b4568Cd242a50c | grep Location

Location: https://itunes.apple.com/us/podcast/artsy/id1096194516?mt=2&utm_source=sailthru&utm_medium=email&utm_campaign=9878256-06-19-17-Editorial&utm_content=banner&utm_term=Editorial%20Email%20-%20Daily
```