### PR TITLE
@alloy => Adds gender-equality slug

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -25,6 +25,7 @@
           "NOT *L2FydGljbGUv*",
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",
+          "NOT *L2dlbmRlci1lcXVhbGl0*",
           "*"
         ]
       }

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -18,6 +18,7 @@
           "NOT /article/*",
           "NOT /2016-year-in-art",
           "NOT /venice-biennale*",
+          "NOT /gender-equality*",
           "NOT /click/*/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS5uZXQv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "artsy-eigen-web-association",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A tiny app that serves the apple-app-site-association required for iOS Handoff related features.",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
For the next feature (December), we'll use a real resource (something like /feature/) so this should be the last one from us. 🤞 

I've notified the #emails team about using the non-www version of the url to stop handoff from the Sailthru side.