### PR TITLE
@alloy => Adds adjust link

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -22,6 +22,7 @@
           "NOT /click/*/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS5uZXQv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",
+          "NOT /click/*/aHR0cHM6Ly9hcHAuYWRqdXN0LmNvbQ*",
           "NOT *L2FydGljbGUv*",
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",


### PR DESCRIPTION
Requested by emails -- I've already uploaded this to ST. The original url used is: https://app.adjust.com

Note, we do have a way to manually avoid redirects by removing the link wrapper altogether but in this case they need to be able to wrap the link (so it can be tracked)