### PR TITLE
prevent collection pages from opening in the app

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ required way.
 
 For more information see:
 
-* [Handoff programming guide](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/AdoptingHandoff/AdoptingHandoff.html#//apple_ref/doc/uid/TP40014338-CH2-SW10)
-* [Universal Links programming guide](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
-* [Shared Web Credentials programming guide](https://developer.apple.com/library/ios/documentation/Security/Reference/SharedWebCredentialsRef/)
-* [Sailthru Universal Links Documentation](https://getstarted.sailthru.com/mobile/apple-ios-app-universal-links/)
-* [Sailthru UL FAQ](https://sailthru.zendesk.com/hc/en-us/articles/217102466-Universal-Links-Troubleshooting-and-FAQ)
+- [Handoff programming guide](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/Handoff/AdoptingHandoff/AdoptingHandoff.html#//apple_ref/doc/uid/TP40014338-CH2-SW10)
+- [Universal Links programming guide](https://developer.apple.com/library/prerelease/ios/documentation/General/Conceptual/AppSearch/UniversalLinks.html)
+- [Shared Web Credentials programming guide](https://developer.apple.com/library/ios/documentation/Security/Reference/SharedWebCredentialsRef/)
+- [Sailthru Universal Links Documentation](https://getstarted.sailthru.com/mobile/apple-ios-app-universal-links/)
+- [Sailthru UL FAQ](https://sailthru.zendesk.com/hc/en-us/articles/217102466-Universal-Links-Troubleshooting-and-FAQ)
 
 ## Serving config file
 
@@ -28,6 +28,10 @@ page](https://my.sailthru.com/settings/universal_links). This uploads the file t
 When making changes, you should do so in the `apple-app-site-association.json`
 file and then run `yarn build` to encode new paths for Sailthru or remove old
 ones.
+
+## After config changes are merged
+
+After changes to the `apple-app-site-association.json` file have been merged, you'll need to update the three places that depend on it which include force, artsy-wwwify, and Sailthru. To update the package in force and artsy-wwwify run the command `yarn upgrade artsy-eigen-web-association` in those repositories and check that in. Updates to Sailthru requires you to notify Sailthru support which someone from `#crm` slack channel can help with.
 
 ## Caching
 

--- a/add-sailthru-paths.js
+++ b/add-sailthru-paths.js
@@ -5,7 +5,7 @@
  *
  * (This specific link redirects to https://www.artsy.net/article/artsy-editorial-mets-roof-hosts-dinner-party-5-000-years-art-invited?utm_source=sailthru&utm_medium=email&utm_campaign=9466122-Editorial-04-25-17&utm_term=ArtsyTopStoriesWeekly)
  *
- * The problem with that is that iOS won’t be able to exclude paths in the normal way. However, it turns out that the
+ * The problem with this is that iOS won’t be able to exclude paths in the normal way. However, it turns out that the
  * encoded URL contains a base64 version of the actual Artsy URL, so we can exclude based on that. This script takes the
  * patterns specified in the apple-app-site-association.json file and generates the encoded versions of them. Or, if a
  * pattern was removed, it removes the corresponding encoded pattern.
@@ -18,7 +18,9 @@ const filename = "apple-app-site-association.json"
 function updateFile(block) {
   const json = JSON.parse(fs.readFileSync(filename, { encoding: "utf8" }))
   block(json)
-  fs.writeFileSync(filename, JSON.stringify(json, null, 2) + "\n", { encoding: "utf8" })
+  fs.writeFileSync(filename, JSON.stringify(json, null, 2) + "\n", {
+    encoding: "utf8"
+  })
 }
 
 function unencodedPatterns(patterns) {
@@ -52,5 +54,10 @@ function encodePattern(pattern) {
 updateFile(json => {
   const app = json.applinks.details[0]
   const patterns = unencodedPatterns(app.paths)
-  app.paths = [...patterns.concat(patterns.filter(isNotSailthruPattern).map(encodePattern)), "*"]
+  app.paths = [
+    ...patterns.concat(
+      patterns.filter(isNotSailthruPattern).map(encodePattern)
+    ),
+    "*"
+  ]
 })

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -32,6 +32,7 @@
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",
           "NOT *L2dlbmRlci1lcXVhbGl0*",
+          "NOT *L2NvbGxlY3Rpb24v*",
           "*"
         ]
       }

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -19,6 +19,7 @@
           "NOT /2016-year-in-art",
           "NOT /venice-biennale*",
           "NOT /gender-equality*",
+          "NOT /collection/*",
           "NOT /click/*/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS5uZXQv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",


### PR DESCRIPTION
Addresses: https://artsyproduct.atlassian.net/browse/GROW-996

This PR adds the collection paths (`/collection/:id`) to the `apple-app-site-association.json` to be blacklisted so that they won't show up in the iOS app. It seems pretty straightforward but I'm wondering how do I go about verifying this. That's why I've marked this as WIP because it's not yet be verified.