### PR TITLE
Prevent facebook auth to open inside the app

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -24,6 +24,7 @@
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS5uZXQv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",
           "NOT /click/*/aHR0cHM6Ly9hcHAuYWRqdXN0LmNv*",
+          "NOT /users/auth/facebook/callback*",
           "NOT *L2FydGljbGUv*",
           "NOT *L3Nlcmll*",
           "NOT *L3ZpZGVv*",


### PR DESCRIPTION
Related: https://artsyproduct.atlassian.net/browse/PURCHASE-805

This should prevent facebook auth redirect URL from opening the Artsy app and keep the flow in mobile web