### PR TITLE
Update apple-app-site-association.json

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -3,7 +3,7 @@
     "apps": ["23KMWZ572J.net.artsy.artsy"]
   },
   "webcredentials": {
-    "apps": ["23KMWZ572J.net.artsy.artsy"]
+    "apps": ["23KMWZ572J.net.artsy.artsy", "23KMWZ572J.net.artsy.Emission", "23KMWZ572J.sy.art.folio"]
   },
   "applinks": {
     "apps": [],


### PR DESCRIPTION
Adds Emission, and Folio to the webcredentials group. Mainly wanted to get the auto-login in Emission eventually.