### PR TITLE
Exclude /identity_verification* from app deeplinking

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -1,6 +1,8 @@
 {
   "activitycontinuation": {
-    "apps": ["23KMWZ572J.net.artsy.artsy"]
+    "apps": [
+      "23KMWZ572J.net.artsy.artsy"
+    ]
   },
   "webcredentials": {
     "apps": [
@@ -31,6 +33,7 @@
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",
           "NOT /click/*/aHR0cHM6Ly9hcHAuYWRqdXN0LmNv*",
           "NOT /users/auth/facebook/callback*",
+          "NOT /identity_verification*",
           "NOT *L2FydGljbGUv*",
           "NOT *L3ZpZGVv*",
           "NOT *L25l*",
@@ -38,6 +41,7 @@
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",
           "NOT *L2dlbmRlci1lcXVhbGl0*",
+          "NOT *L2lkZW50aXR5X3ZlcmlmaWNhdGlv*",
           "*"
         ]
       }


### PR DESCRIPTION
JIRA: https://artsyproduct.atlassian.net/browse/AUCT-906

* commits output of `yarn build`, but removing `NOT **` entries which
  aren't desirable. See [this GH comment][0].

[0]:https://github.com/artsy/artsy-eigen-web-association/pull/27#discussion_r376425914

TODO:
- [ ] Update ~Sailtru~ Force
- [ ] Update artsy-wwwify
- [ ] Update sailthru

*Updates to Sailthru requires you to notify Sailthru support and provide them with the updated apple-app-site-association.json file.