### PR TITLE
Deeplink `/identity-verification*`, not `/identity_verification*`

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -33,7 +33,7 @@
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",
           "NOT /click/*/aHR0cHM6Ly9hcHAuYWRqdXN0LmNv*",
           "NOT /users/auth/facebook/callback*",
-          "NOT /identity_verification*",
+          "NOT /identity-verification*",
           "NOT *L2FydGljbGUv*",
           "NOT *L3ZpZGVv*",
           "NOT *L25l*",
@@ -41,7 +41,7 @@
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",
           "NOT *L2dlbmRlci1lcXVhbGl0*",
-          "NOT *L2lkZW50aXR5X3ZlcmlmaWNhdGlv*",
+          "NOT *L2lkZW50aXR5LXZlcmlmaWNhdGlv*",
           "*"
         ]
       }


### PR DESCRIPTION
- See this commit for more context:
ebdfa775597ba4f122e3512c5dce505316bc8b8b
- Slack thread with guidance on `-` versus `_`:
https://artsy.slack.com/archives/CA8SANW3W/p1582734582132900

Jira: https://artsyproduct.atlassian.net/browse/AUCT-906