### PR TITLE
Sailthru script fix, and updates

### DIFF
--- a/add-sailthru-paths.js
+++ b/add-sailthru-paths.js
@@ -11,28 +11,28 @@
  * pattern was removed, it removes the corresponding encoded pattern.
  */
 
-const fs = require("fs")
+const fs = require('fs')
 
-const filename = "apple-app-site-association.json"
+const filename = 'apple-app-site-association.json'
 
 function updateFile(block) {
-  const json = JSON.parse(fs.readFileSync(filename, { encoding: "utf8" }))
+  const json = JSON.parse(fs.readFileSync(filename, { encoding: 'utf8' }))
   block(json)
-  fs.writeFileSync(filename, JSON.stringify(json, null, 2) + "\n", {
-    encoding: "utf8"
+  fs.writeFileSync(filename, JSON.stringify(json, null, 2) + '\n', {
+    encoding: 'utf8'
   })
 }
 
 function unencodedPatterns(patterns) {
-  return patterns.filter(pattern => pattern.includes("/"))
+  return patterns.filter(pattern => pattern.includes('/'))
 }
 
 function encodePath(path) {
   return path
-    .split("*")
+    .split('*')
     .filter(component => component.length)
-    .map(component => new Buffer(component).toString("base64"))
-    .join("*")
+    .map(component => new Buffer(component).toString('base64'))
+    .join('*')
 }
 
 function isNotSailthruPattern(pattern) {
@@ -47,7 +47,7 @@ function isNotSailthruPattern(pattern) {
  */
 function encodePattern(pattern) {
   const path = pattern.match(/^NOT (.+)$/)[1]
-  const encoded = encodePath(path.slice(0, -(path.length % 3)))
+  const encoded = encodePath(path.slice(0, path.length - (path.length % 3)))
   return `NOT *${encoded}*`
 }
 
@@ -58,6 +58,6 @@ updateFile(json => {
     ...patterns.concat(
       patterns.filter(isNotSailthruPattern).map(encodePattern)
     ),
-    "*"
+    '*'
   ]
 })

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -28,6 +28,8 @@
           "NOT /venice-biennale*",
           "NOT /gender-equality*",
           "NOT /collections",
+          "NOT /log_in",
+          "NOT /sign_up",
           "NOT /click/*/aHR0cHM6Ly9pdHVuZXMuYXBwbGUuY29tL3VzL3BvZGNhc3QvYXJ0c3kv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS5uZXQv*",
           "NOT /click/*/aHR0cHM6Ly9hcnRzeS50eXBlZm9ybS5j*",
@@ -45,6 +47,8 @@
           "NOT *L3ZlbmljZS1iaWVubmFs*",
           "NOT *L2dlbmRlci1lcXVhbGl0*",
           "NOT *L2NvbGxlY3Rpb25z*",
+          "NOT *L2xvZ19p*",
+          "NOT *L3NpZ25f*",
           "NOT *L3VzZXJzL2F1dGgvZmFjZWJvb2svY2FsbGJhY2s=*",
           "NOT *L2lkZW50aXR5LXZlcmlmaWNhdGlv*",
           "*"

--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -34,13 +34,18 @@
           "NOT /click/*/aHR0cHM6Ly9hcHAuYWRqdXN0LmNv*",
           "NOT /users/auth/facebook/callback*",
           "NOT /identity-verification*",
+          "NOT *L2FydGljbGVz*",
           "NOT *L2FydGljbGUv*",
+          "NOT *L3Nlcmllcy8=*",
           "NOT *L3ZpZGVv*",
           "NOT *L25l*",
           "NOT *L25ld3Mv*",
+          "NOT *L2VkaXRvcmlhbC8=*",
           "NOT *LzIwMTYteWVhci1pbi1h*",
           "NOT *L3ZlbmljZS1iaWVubmFs*",
           "NOT *L2dlbmRlci1lcXVhbGl0*",
+          "NOT *L2NvbGxlY3Rpb25z*",
+          "NOT *L3VzZXJzL2F1dGgvZmFjZWJvb2svY2FsbGJhY2s=*",
           "NOT *L2lkZW50aXR5LXZlcmlmaWNhdGlv*",
           "*"
         ]


### PR DESCRIPTION
This fixes the Sailthru url-encoding script, as well as adds the `log_in` and `sign_up` paths to the excluded list. I noticed this was opened [in a crash](https://sentry.io/organizations/artsynet/issues/1091736073/events/31b783347d0347bcb6689b3b3d5faa1e/?project=166784) that inexplicably caused a stack overflow. I don't understand it, but in any case, we shouldn't be linking into the app on these URLs because the app doesn't know how to route them correctly. /cc @ds300 

I'll inline an explanation of the script fix, since Prettier made the changes hard to isolate. 