### PR TITLE
fix: add google callback to denylist

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -32,6 +32,7 @@
           "NOT /series/*",
           "NOT /sign_up",
           "NOT /users/auth/facebook/callback*",
+          "NOT /users/auth/google/callback*",
           "NOT /venice-biennale*",
           "NOT /video/*",
           "*"


### PR DESCRIPTION
Prevent google sign in callbacks from opening the artsy app.