### PR TITLE
fix: add other login endpoints

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -25,6 +25,8 @@
           "NOT /gender-equality*",
           "NOT /identity-verification*",
           "NOT /log_in",
+          "NOT /login",
+          "NOT /#",
           "NOT /news",
           "NOT /news/*",
           "NOT /price-database",


### PR DESCRIPTION
went through google sign in flow with a few accounts, these endpoints are hit either if errors are hit with 3rd party auth or to land you on artsy.net at the end of a successful flow. 

