### PR TITLE
fix: add new sign up endpoint

### DIFF
--- a/apple-app-site-association.json
+++ b/apple-app-site-association.json
@@ -33,6 +33,7 @@
           "NOT /reset_password",
           "NOT /series/*",
           "NOT /sign_up",
+          "NOT /signup",
           "NOT /users/auth/facebook/callback*",
           "NOT /users/auth/google/callback*",
           "NOT /venice-biennale*",


### PR DESCRIPTION
looks like we removed underscore for sign up endpoint, prevent deeplinking